### PR TITLE
JSON query string should be URL-encoded

### DIFF
--- a/lib/Semantics3/ApiConnector.php
+++ b/lib/Semantics3/ApiConnector.php
@@ -23,7 +23,7 @@ abstract class Api_Connector
     OAuthStore::instance("2Leg", $options );
     $url = $this->apiBase.$endpoint;
     if ($method == "GET") {
-      $url = $url."?q=".json_encode($params);
+      $url = $url."?q=".urlencode(json_encode($params));
       $params = null;
     }
     else {


### PR DESCRIPTION
This line breaks as soon as you have a non-normal string in your search query. Example is a product id with a hash mark in it.