### PR TITLE
Fix: Add missing .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock


### PR DESCRIPTION
This PR

* [x] adds a `.gitignore`

Related to https://github.com/Semantics3/semantics3-php/pull/19.

💁‍♂️ When cloning this repository and running

```
$ composer install
```

we end up with a dirty index. 

We should definitely ignore `vendor`, and since this is a library, as opposed to an application, we probably don't want to check in `composer.lock`.