### PR TITLE
Fix: Remove broken link to Quickstart Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 semantics3-php is the PHP bindings for accessing the Semantics3 Products API, which provides structured information, including pricing histories, for a large number of products.
 See https://www.semantics3.com for more information.
 
-Quickstart guide: https://www.semantics3.com/quickstart
 API documentation can be found at https://www.semantics3.com/docs/
 
 ## Installation


### PR DESCRIPTION
This PR

* [x] removes a broken link to the Quickstart Guide

💁‍♂️ Maybe you prefer to replace it with one that works? 

Navigating to https://www.semantics3.com/quickstart yields:

![screen shot 2017-03-01 at 17 04 10](https://cloud.githubusercontent.com/assets/605483/23468442/1db2e5e4-fea1-11e6-806d-856fc08ae2ae.png)
