### PR TITLE
Fix: Let OAuthException2 bubble up

### DIFF
--- a/lib/Semantics3/ApiConnector.php
+++ b/lib/Semantics3/ApiConnector.php
@@ -11,6 +11,17 @@ abstract class Api_Connector
     $this->apiBase = is_null($apiBase) ? "https://api.semantics3.com/v1/" : $apiBase;
   }
 
+  /**
+   * @param string $endpoint
+   * @param array  $params
+   * @param string $method
+   * @param array  $requestOptions
+   *
+   * @return array
+   *
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   */
   public function run_query($endpoint, $params, $method="GET", array $requestOptions = [])
   {
     if (!$this->apiKey)
@@ -29,35 +40,26 @@ abstract class Api_Connector
       $params = json_encode($params);
     }
 
-    try
-    {
-      switch ($method) {
-        case "GET":
-          $request = new OAuthRequester($url, $method);
-          break;
-        case "POST":
-          $request = new OAuthRequester($url, $method, '', $params);
-          break;
-        case "DELETE":
-          $request = new OAuthRequester($url, $method);
-          break;
-        default:
-          $request = new OAuthRequester($url, $method);
-      }
-
-      $usrId = array_key_exists('usrId', $requestOptions) ? $requestOptions['usrId'] : 0;
-      $curlOptions = array_key_exists('curlOptions', $requestOptions) ? $requestOptions['curlOptions'] : [];
-      $options = array_key_exists('options', $requestOptions) ? $requestOptions['options'] : [];
-
-      $result = $request->doRequest($usrId, $curlOptions, $options);
-      return $result['body'];
-    }
-    catch(OAuthException2 $e)
-    {
-      print "\n";
-      $error = $e->getMessage();
-      print $error."\n";
+    switch ($method) {
+      case "GET":
+        $request = new OAuthRequester($url, $method);
+        break;
+      case "POST":
+        $request = new OAuthRequester($url, $method, '', $params);
+        break;
+      case "DELETE":
+        $request = new OAuthRequester($url, $method);
+        break;
+      default:
+        $request = new OAuthRequester($url, $method);
     }
 
+    $usrId = array_key_exists('usrId', $requestOptions) ? $requestOptions['usrId'] : 0;
+    $curlOptions = array_key_exists('curlOptions', $requestOptions) ? $requestOptions['curlOptions'] : [];
+    $options = array_key_exists('options', $requestOptions) ? $requestOptions['options'] : [];
+
+    $result = $request->doRequest($usrId, $curlOptions, $options);
+
+    return $result['body'];
   }
 }

--- a/lib/Semantics3/Products.php
+++ b/lib/Semantics3/Products.php
@@ -75,13 +75,24 @@ class Semantics3_Products extends Api_Connector {
    * get the categories from the API
    * 
    * This function calls the API and returns the categories based on the query
+   *
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   *
+   * @return array
    */
   public function get_categories(){
     $this->_query_result = parent::run_query("categories",$this->_data_query["categories"]);
     return $this->_query_result;
   }
 
-    public function get_offers(){
+  /**
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   *
+   * @return array
+   */
+  public function get_offers(){
     $this->_query_result = parent::run_query("offers",$this->_data_query["offers"]);
     return $this->_query_result;
   }
@@ -179,6 +190,15 @@ class Semantics3_Products extends Api_Connector {
     return array_key_exists('results', $query_result) ? $query_result['results'] : 0;
   }
 
+  /**
+   * @param string $endpoint
+   * @param string $query_json
+   *
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   *
+   * @return array
+   */
   public function query_json($endpoint, $query_json){
     $this->_query_result = parent::run_query($endpoint,json_decode($query_json));
     return $this->_query_result;
@@ -198,11 +218,26 @@ class Semantics3_Products extends Api_Connector {
     return $this->_data_query[$endpoint];
   }
 
+  /**
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   *
+   * @return array
+   */
   public function get_products(){
     $this->_query_result = parent::run_query("products",$this->_data_query["products"]);
     return $this->_query_result;
   }
 
+  /**
+   * @param string $endpoint
+   * @param array  $query_arr
+   *
+   * @throws Semantics3_AuthenticationError
+   * @throws OAuthException2
+   *
+   * @return array
+   */
   public function query($endpoint, $query_arr = array()){
     $this->_query_result = parent::run_query($endpoint,$query_arr);
     return $this->_query_result;


### PR DESCRIPTION
This PR

* [x] lets `OauthException2` bubble up instead of inappropriately handling it within `Api_Connector` and updates docblocks of affected methods

Related to #25.