### PR TITLE
Refactor: extract request logic to distinct public function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.2"
+    "php": ">=5.4"
   },
   "autoload": {
     "classmap": ["lib/Semantics3/"]


### PR DESCRIPTION
# What
Refactors the request construction logic for the ApiConstructor class to allow users to manage the request object manually instead of deferring to stderr/stdout, while preserving functionality for original `run_query` output.